### PR TITLE
Add climate.js site-wide

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,5 +22,9 @@ url: ''
 twitter_username: 18F
 github_username:  18F
 
+# scripts to load on all pages
+scripts:
+- climate.js
+
 # Build settings
 markdown: kramdown

--- a/js/climate.js
+++ b/js/climate.js
@@ -1,0 +1,27 @@
+(function(exports) {
+
+  exports.parseQueryString = function parseQueryString(qs) {
+    if (!qs || qs === '?') {
+      return {};
+    }
+
+    var parts = qs.replace(/^\?/, '').split('&');
+    var decode = function(str) {
+      return decodeURIComponent(str).replace(/\+/g, ' ');
+    };
+
+    return parts.reduce(function(q, part) {
+      var i = part.indexOf('=');
+      if (i > -1) {
+        var key = part.substr(0, i);
+        var val = part.substr(i + 1);
+        q[key] = decode(val);
+      } else {
+        q[part] = true;
+      }
+      return q;
+    }, {});
+
+  };
+
+})(window.climate = {});


### PR DESCRIPTION
@jeremiak I know we're going to have some common JS stuff, so I made a place for it in `js/climate.js` and added it to `site.scripts` in the Jekyll config so it's available on every page. So far there's just one method: `climate.parseQueryString(String):Object`
