### PR TITLE
Use lighter font for report finding paragraphs

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -305,6 +305,12 @@ section .container {
     }
   }
 
+  ul p,
+  #methodology ~ p {
+    font-size: .9em;
+    font-weight: 100;
+  }
+
   h3 + p {
     margin-top: 0;
   }


### PR DESCRIPTION
[Preview on Federalist](https://federalist.18f.gov/preview/18f/climate-labs/jk-lighter-font/)

To better match the design, all paragraph elements that are within the report findings UL or related to the methodology have a much lighter font weight and a smaller font size.