### PR TITLE
Add excluded files to Jekyll config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,6 +10,15 @@ title: Climate Labs Microsite
 
 email: climate-data-user-study@gsa.gov
 
+# Exclude files
+exclude:
+- Gemfile
+- Gemfile.lock
+- README.md
+- LICENSE
+- package.json
+- node_modules
+
 # this means to ignore newlines until "baseurl:"
 description: ''
 


### PR DESCRIPTION
Currently, this site is uploading its node modules directory. This directory contains the javascript files necessary to build the site's assets, but not necessary to display the site. When a lot of these files are present, it can take significantly longer for Federalist to build and upload the site.

This commit adds the `node_modules` directory, along with some other files, to a list under the `exclude` option in the Jekyll configuration. This will prevent those files from being built into the site in the future.

Ref 18f/federalist#735